### PR TITLE
Prefix Configuration Issue on Windows #121

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -7,7 +7,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import * as util from 'util'
 
-const prefix = __dirname.indexOf('/build/') >= 0 ? '../../../' : '../'
+const prefix = __dirname.replace(/\\/g,'/').indexOf('/build/') >= 0 ? '../../../' : '../'
 const pkg = require(prefix + '/package.json')
 
 export default class Configuration {


### PR DESCRIPTION
# Problem
This PR is related to the issue found in Windows environment when trying to start any script. Because of the way windows describe the path(e.g. 'C:\some\directory\to\configuration.js') causes the <code>indexOf('/build/')</code> to always return -1 what gives us the wrong prefix. 

# Solution
The small piece of code guarantees the replace from "\\" to "/". Nevetherless, it makes the prefix generation compliant with Unix and Windows environments. I am open to any better solution suggestion.