### PR TITLE
removes all listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "debug": "3.1.0",
     "deep-metrics": "0.0.2",
     "deepmerge": "2.1.0",
+    "event-loop-inspector": "1.0.1",
     "json-stringify-safe": "5.0.1",
     "semver": "5.5.0",
     "signal-exit": "3.0.2",

--- a/src/actions/eventLoopInspector.ts
+++ b/src/actions/eventLoopInspector.ts
@@ -1,13 +1,8 @@
-import Debug from 'debug'
-const debug = Debug('axm:eventloopaction')
-
-import utils from '../utils/module'
 import ActionsFeature from '../features/actions'
 import ActionsInterface from './actionsInterface'
 
 export default class Inspector implements ActionsInterface {
 
-  private MODULE_NAME = 'event-loop-inspector'
   private actionFeature: ActionsFeature
 
   constructor (actionFeature: ActionsFeature) {
@@ -16,34 +11,17 @@ export default class Inspector implements ActionsInterface {
 
   async init () {
     return new Promise((resolve, reject) => {
-      utils.detectModule(this.MODULE_NAME, (err, inspectorPath) => {
 
-        if (err) {
-          debug(err)
-          return reject(err)
-        }
+      this.exposeActions()
 
-        const res = this.exposeActions(inspectorPath)
-
-        if (res instanceof Error) {
-          return reject(res)
-        }
-        return resolve()
-      })
+      return resolve()
     }).catch((e) => console.error(e))
   }
 
-  private exposeActions (inspectorPath) {
-    let inspector = utils.loadModule(inspectorPath, this.MODULE_NAME, [true])
+  private exposeActions () {
+    let inspector = require('event-loop-inspector')(true)
 
-    if (inspector instanceof Error || !inspector) {
-      return inspector
-    }
-
-    /**
-     * Heap snapshot
-     */
-    return this.actionFeature.action('km:event-loop-dump', function (reply) {
+    this.actionFeature.action('km:event-loop-dump', function (reply) {
       const dump = inspector.dump()
 
       return reply({

--- a/src/features/actions.ts
+++ b/src/features/actions.ts
@@ -24,11 +24,13 @@ export default class ActionsFeature implements Feature {
 
       if (!dump || (dump.setImmediates.length === 0 &&
           dump.nextTicks.length === 0 &&
-          (Object.keys(dump.handles).length === 0 || (dump.handles.hasOwnProperty('Socket') &&
+          (Object.keys(dump.handles).length === 0 || (Object(dump.handles).keys === 1 &&
+            dump.handles.hasOwnProperty('Socket') &&
             dump.handles.Socket.length === 2 &&
             dump.handles.Socket[0].fd === 1 &&
             dump.handles.Socket[1].fd === 2)) &&
           Object.keys(dump.requests).length === 0)) {
+        console.log(dump)
         process.removeListener('message', this.listener)
       }
     }, 1000)

--- a/src/features/actions.ts
+++ b/src/features/actions.ts
@@ -24,7 +24,10 @@ export default class ActionsFeature implements Feature {
 
       if (!dump || (dump.setImmediates.length === 0 &&
           dump.nextTicks.length === 0 &&
-          Object.keys(dump.handles).length === 0 &&
+          (Object.keys(dump.handles).length === 0 || (dump.handles.hasOwnProperty('Socket') &&
+            dump.handles.Socket.length === 2 &&
+            dump.handles.Socket[0].fd === 1 &&
+            dump.handles.Socket[1].fd === 2)) &&
           Object.keys(dump.requests).length === 0)) {
         process.removeListener('message', this.listener)
       }

--- a/test/actions/eventLoopInspector.spec.ts
+++ b/test/actions/eventLoopInspector.spec.ts
@@ -20,7 +20,6 @@ describe('EventLoopInspector', function () {
 
           expect(res.data.return.success).to.equal(true)
           expect(typeof res.data.return.dump).to.equal('object')
-
           child.kill('SIGINT')
         }
       })

--- a/test/actions/eventLoopInspector.spec.ts
+++ b/test/actions/eventLoopInspector.spec.ts
@@ -5,7 +5,7 @@ import Inspector from '../../src/actions/eventLoopInspector'
 import Action from '../../src/features/actions'
 
 describe('EventLoopInspector', function () {
-  this.timeout(50000)
+  this.timeout(20000)
 
   describe('Event loop inspector module', function () {
 
@@ -24,12 +24,16 @@ describe('EventLoopInspector', function () {
           expect(typeof res.data.return.dump).to.equal('object')
 
           child.kill('SIGINT')
-          done()
         }
       })
 
-      setTimeout(function () {
+      child.on('exit', function() {
+        done()
+      })
+
+      const timer = setTimeout(function () {
         child.send('km:event-loop-dump')
+        clearTimeout(timer)
       }, 2000)
     })
   })

--- a/test/actions/eventLoopInspector.spec.ts
+++ b/test/actions/eventLoopInspector.spec.ts
@@ -4,22 +4,10 @@ import { fork, exec } from 'child_process'
 import Inspector from '../../src/actions/eventLoopInspector'
 import Action from '../../src/features/actions'
 
-const MODULE = 'event-loop-inspector'
-
 describe('EventLoopInspector', function () {
   this.timeout(50000)
 
   describe('Event loop inspector module', function () {
-    before(function (done) {
-      exec('npm install ' + MODULE, function (err) {
-        expect(err).to.equal(null)
-        setTimeout(done, 1000)
-      })
-    })
-
-    after(function (done) {
-      exec('npm uninstall ' + MODULE, done)
-    })
 
     it('should get event loop data', (done) => {
       const child = fork(SpecUtils.buildTestPath('fixtures/actions/eventLoopInspectorChild.js'))
@@ -43,38 +31,6 @@ describe('EventLoopInspector', function () {
       setTimeout(function () {
         child.send('km:event-loop-dump')
       }, 2000)
-    })
-  })
-
-  describe('Event loop inspector module not install', function () {
-
-    before(function (done) {
-      exec('npm uninstall ' + MODULE, done)
-    })
-
-    it('should display error message cause module is not present', async () => {
-      const action = new Action()
-      action.init()
-
-      const eventLoopInspector = new Inspector(action)
-
-      await eventLoopInspector.init().catch((e) => {
-        expect(e.message).to.equal('event-loop-inspector not found')
-      })
-    })
-
-    it('should catch error cause module is not present', async () => {
-      const action = new Action()
-      action.init()
-
-      const eventLoopInspector = new Inspector(action)
-
-      try {
-        await eventLoopInspector.init()
-      } catch (e) {
-        assert.fail(e)
-      }
-
     })
   })
 })

--- a/test/actions/eventLoopInspector.spec.ts
+++ b/test/actions/eventLoopInspector.spec.ts
@@ -1,8 +1,6 @@
 import SpecUtils from '../fixtures/utils'
 import { expect, assert } from 'chai'
 import { fork, exec } from 'child_process'
-import Inspector from '../../src/actions/eventLoopInspector'
-import Action from '../../src/features/actions'
 
 describe('EventLoopInspector', function () {
   this.timeout(20000)
@@ -27,7 +25,7 @@ describe('EventLoopInspector', function () {
         }
       })
 
-      child.on('exit', function() {
+      child.on('exit', function () {
         done()
       })
 

--- a/test/autoExit.spec.ts
+++ b/test/autoExit.spec.ts
@@ -6,7 +6,7 @@ import { exec, fork } from 'child_process'
 import Histogram from '../src/utils/metrics/histogram'
 
 describe('API', function () {
-  this.timeout(5000)
+  this.timeout(10000)
 
   describe('AutoExit program', () => {
     it('should exit program when it has no more tasks to process', (done) => {

--- a/test/autoExit.spec.ts
+++ b/test/autoExit.spec.ts
@@ -1,0 +1,20 @@
+import SpecUtils from './fixtures/utils'
+import { assert, expect } from 'chai'
+import 'mocha'
+
+import { exec, fork } from 'child_process'
+import Histogram from '../src/utils/metrics/histogram'
+
+describe('API', function () {
+  this.timeout(5000)
+
+  describe('AutoExit program', () => {
+    it('should exit program when it has no more tasks to process', (done) => {
+      const child = fork(SpecUtils.buildTestPath('fixtures/autoExitChild.js'))
+
+      child.on('exit', () => {
+        done()
+      })
+    })
+  })
+})

--- a/test/fixtures/actions/eventLoopInspectorChild.ts
+++ b/test/fixtures/actions/eventLoopInspectorChild.ts
@@ -1,13 +1,13 @@
 import Action from '../../../src/features/actions'
 import Inspector from '../../../src/actions/eventLoopInspector'
 
+// set something into event loop. Else test will exit immediately
+const timer = setInterval(function () {}, 5000)
+
 const action = new Action()
 action.init({
   eventLoopDump: true
 })
-
-// set something into event loop. Else test will exit immediately
-const timer = setInterval(function () {}, 5000)
 
 process.on('SIGINT', function () {
   action.destroy()

--- a/test/fixtures/actions/eventLoopInspectorChild.ts
+++ b/test/fixtures/actions/eventLoopInspectorChild.ts
@@ -6,3 +6,11 @@ action.init()
 
 const eventLoopInspector = new Inspector(action)
 eventLoopInspector.init()
+
+// set something into event loop. Else test will exit immediately
+const timer = setInterval(function () {}, 5000)
+
+process.on('SIGINT', function () {
+  action.destroy()
+  clearInterval(timer)
+})

--- a/test/fixtures/actions/eventLoopInspectorChild.ts
+++ b/test/fixtures/actions/eventLoopInspectorChild.ts
@@ -2,10 +2,9 @@ import Action from '../../../src/features/actions'
 import Inspector from '../../../src/actions/eventLoopInspector'
 
 const action = new Action()
-action.init()
-
-const eventLoopInspector = new Inspector(action)
-eventLoopInspector.init()
+action.init({
+  eventLoopDump: true
+})
 
 // set something into event loop. Else test will exit immediately
 const timer = setInterval(function () {}, 5000)

--- a/test/fixtures/autoExitChild.ts
+++ b/test/fixtures/autoExitChild.ts
@@ -6,6 +6,7 @@ io.init()
 
 // simple timeout to make event loop working
 // after 1 seconds this script should exit
-setTimeout(function () {
-
+const timer = setTimeout(function () {
+  io.destroy()
+  clearTimeout(timer)
 }, 200)

--- a/test/fixtures/autoExitChild.ts
+++ b/test/fixtures/autoExitChild.ts
@@ -8,4 +8,4 @@ io.init()
 // after 1 seconds this script should exit
 setTimeout(function() {
 
-}, 1000)
+}, 2000)

--- a/test/fixtures/autoExitChild.ts
+++ b/test/fixtures/autoExitChild.ts
@@ -1,0 +1,11 @@
+import SpecUtils from './utils'
+
+const io = require(__dirname + '/../../src/index.js')
+
+io.init()
+
+// simple timeout to make event loop working
+// after 1 seconds this script should exit
+setTimeout(function() {
+
+}, 1000)

--- a/test/fixtures/autoExitChild.ts
+++ b/test/fixtures/autoExitChild.ts
@@ -6,6 +6,6 @@ io.init()
 
 // simple timeout to make event loop working
 // after 1 seconds this script should exit
-setTimeout(function() {
+setTimeout(function () {
 
-}, 2000)
+}, 200)


### PR DESCRIPTION
2 questions : 

- Is it ok to add event-loop-inspector as dependency ?

- Do we need a fallback in case we remove listener but application doesn't exit ?
In this case we can put back in place listener and check again event loop status.