### PR TITLE
perf: disable async stracktrace by default

### DIFF
--- a/src/features/notifyInspector.ts
+++ b/src/features/notifyInspector.ts
@@ -223,9 +223,11 @@ export default class NotifyInspector {
     process.on('unhandledRejection', this.trapException('unhandledRejection'))
     // enable all the debugger options
     session.post('Debugger.enable')
-    session.post('Debugger.setAsyncCallStackDepth', {
-      maxDepth: process.env.PM2_APM_ASYNC_STACK_DEPTH || 50
-    })
+    const maxDepth = parseInt(process.env.PM2_APM_ASYNC_STACK_DEPTH || '')
+    if (!isNaN(maxDepth)) {
+      session.post('Debugger.setAsyncCallStackDepth', { maxDepth })
+    }
+    
     session.post('Debugger.setPauseOnExceptions', { state: 'uncaught' })
     // register handler for paused event
     session.on('Debugger.paused', ({ params }) => {

--- a/test/features/notify.spec.ts
+++ b/test/features/notify.spec.ts
@@ -67,7 +67,8 @@ describe('Notify', () => {
         env: Object.assign({}, process.env, {
           CATCH_CONTEXT_ON_ERROR: 'true',
           FORCE_INSPECTOR: 1,
-          DEBUG: 'axm:notify'
+          DEBUG: 'axm:notify',
+          PM2_APM_ASYNC_STACK_DEPTH: 50
         })
       })
       child.on('message', msg => {


### PR DESCRIPTION
Async stacktrace are provided by `async_hooks` via the V8 StackTrace API and it seems there are a big performance issue currently, disabling it by default for now