### PR TITLE
Do not swallow errors in koaErrorHandler (fixes #230)

### DIFF
--- a/src/features/notify.ts
+++ b/src/features/notify.ts
@@ -189,6 +189,7 @@ export class NotifyFeature implements Feature {
         if (ServiceManager.get('transport')) {
           ServiceManager.get('transport').send('process:exception', payload)
         }
+        throw err
       }
     }
   }

--- a/test/api.spec.ts
+++ b/test/api.spec.ts
@@ -259,6 +259,22 @@ describe('API', function () {
       })
     })
 
+    it('should not make errors swallowed when koaErrorHandler is used', (done) => {
+      if (semver.satisfies(process.version, '<= 6.0.0')) return done()
+      const child = launch('fixtures/apiKoaErrorHandler')
+
+      child.on('message', msg => {
+        if (msg === 'ready') {
+          const httpModule = require('http')
+          httpModule.get('http://localhost:3003/error', ({ statusCode }) => {
+            expect(statusCode).to.equal(500)
+            child.kill('SIGINT')
+            done()
+          })
+        }
+      })
+    })
+
     it('should enable tracing + metrics', (done) => {
       const child = launch('fixtures/apiBackwardConfChild')
       let tracingDone = false


### PR DESCRIPTION
As described in #230, the usage of the `koaErrorHandler` silently converted errors to 404s (by not rethrowing them), altering the behavior of the application and essentially swallowing the error.

This commit adds a `throw err;` at the end as well as a unit test for it.