### PR TITLE
Handle non-Error objects thrown as error gracefully, still attempt to report them in a useful way

### DIFF
--- a/src/features/notify.ts
+++ b/src/features/notify.ts
@@ -89,10 +89,12 @@ export class NotifyFeature implements Feature {
       console.error(error)
     }
 
+    const safeError = error instanceof Error ? error : new Error(JSON.stringify(error))
+
     const payload = {
-      message: error.message,
-      stack: error.stack,
-      name: error.name
+      message: safeError.message,
+      stack: safeError.stack,
+      name: safeError.name
     }
 
     if (ServiceManager.get('transport')) {
@@ -107,10 +109,12 @@ export class NotifyFeature implements Feature {
 
     console.error(error)
 
+    const safeError = error instanceof Error ? error : new Error(JSON.stringify(error))
+
     const payload = {
-      message: error.message,
-      stack: error.stack,
-      name: error.name
+      message: safeError.message,
+      stack: safeError.stack,
+      name: safeError.name
     }
 
     if (ServiceManager.get('transport')) {
@@ -132,10 +136,11 @@ export class NotifyFeature implements Feature {
       error : true
     })
     return function errorHandler (err, req, res, next) {
+      const safeError = err instanceof Error ? err : new Error(JSON.stringify(err))
       const payload = {
-        message: err.message,
-        stack: err.stack,
-        name: err.name,
+        message: safeError.message,
+        stack: safeError.stack,
+        name: safeError.name,
         metadata: {
           http: {
             url: req.url,
@@ -167,10 +172,11 @@ export class NotifyFeature implements Feature {
       try {
         await next()
       } catch (err) {
+        const safeError = err instanceof Error ? err : new Error(JSON.stringify(err))
         const payload = {
-          message: err.message,
-          stack: err.stack,
-          name: err.name,
+          message: safeError.message,
+          stack: safeError.stack,
+          name: safeError.name,
           metadata: {
             http: {
               url: ctx.request.url,

--- a/src/features/notify.ts
+++ b/src/features/notify.ts
@@ -56,26 +56,21 @@ export class NotifyFeature implements Feature {
     this.logger('destroy')
   }
 
-  notifyError (err: Error, context?: ErrorContext) {
+  notifyError (err, context?: ErrorContext) {
     // set default context
     if (typeof context !== 'object') {
       context = { }
-    }
-
-    if (!(err instanceof Error)) {
-      console.error('You must use notifyError with an Error object, ignoring')
-      console.trace()
-      return -1
     }
 
     if (this.transport === undefined) {
       return this.logger(`Tried to send error without having transporter available`)
     }
 
+    const safeError = err instanceof Error ? err : new Error(JSON.stringify(error))
     const payload = {
-      message: err.message,
-      stack: err.stack,
-      name: err.name,
+      message: safeError.message,
+      stack: safeError.stack,
+      name: safeError.name,
       metadata: context
     }
 

--- a/src/features/notify.ts
+++ b/src/features/notify.ts
@@ -59,12 +59,12 @@ export class NotifyFeature implements Feature {
   getSafeError (err): Error {
     if (err instanceof Error) return err
 
-    let message
+    let message: string
     try {
       message = `Non-error value: ${JSON.stringify(err)}`
     } catch (e) {
       // We might land here if the error value was not serializable (it might contain
-      // circular references for example), of if user code was ran as part of the
+      // circular references for example), or if user code was ran as part of the
       // serialization and that code threw an error.
       // As alternative, we can try converting the error to a string instead:
       try {

--- a/src/features/notify.ts
+++ b/src/features/notify.ts
@@ -85,7 +85,7 @@ export class NotifyFeature implements Feature {
     return new Error(message)
   }
 
-  notifyError (err, context?: ErrorContext) {
+  notifyError (err: Error | string | {}, context?: ErrorContext) {
     // set default context
     if (typeof context !== 'object') {
       context = { }

--- a/src/pmx.ts
+++ b/src/pmx.ts
@@ -176,7 +176,7 @@ export default class PMX {
    * Notify an error to PM2 Plus/Enterprise, note that you can attach a context to it
    * to provide more insight about the error
    */
-  notifyError (error: Error, context?: ErrorContext) {
+  notifyError (error, context?: ErrorContext) {
     const notify = this.featureManager.get('notify') as NotifyFeature
     return notify.notifyError(error, context)
   }

--- a/src/pmx.ts
+++ b/src/pmx.ts
@@ -176,7 +176,7 @@ export default class PMX {
    * Notify an error to PM2 Plus/Enterprise, note that you can attach a context to it
    * to provide more insight about the error
    */
-  notifyError (error, context?: ErrorContext) {
+  notifyError (error: Error | string | {}, context?: ErrorContext) {
     const notify = this.featureManager.get('notify') as NotifyFeature
     return notify.notifyError(error, context)
   }

--- a/test/fixtures/apiNotifyChild.ts
+++ b/test/fixtures/apiNotifyChild.ts
@@ -2,4 +2,8 @@
 import * as pmx from '../../src/index'
 
 pmx.init()
-pmx.notifyError(new Error('myNotify'))
+try {
+  throw new Error('myNotify')
+} catch (err) {
+  pmx.notifyError(err)
+}


### PR DESCRIPTION
Some code (unfortunately) throws things that are not `Error` objects. The things thrown may be raw data returned from an API, plain objects, strings, in the worst case even `null` or `undefined`.

While `notifyError` did already reject things that were not `Error` objects, the other handlers (uncaught exception, unhandled rejection, Express/Koa middlewares) did not.

I think that
a) The behavior should be the same regardless which handler handles the error
b) Things that are not `Error` objects should still be reported in the most meaningful way (i.e. giving the developer enough information to understand what the error actually was).

Therefore, I modified the behavior so that things other than `Error`s are simply converted to an `Error` with the JSON representation of the old data as `message`.

Even though the stack of those errors is then meaningless, the JSON data should give the developer enough information, definitely more than not seeing the error at all (old behavior of `notifyError`), getting no description of the error (old behavior of the other handlers, since `err.message` may simply be undefined) or crashing in a weird way (old behavior of the other handlers in the case that the error was `null` or `undefined`).