### PR TITLE
Modified pg path in open census plugin

### DIFF
--- a/src/census/plugins/__tests__/pg.spec.ts
+++ b/src/census/plugins/__tests__/pg.spec.ts
@@ -70,7 +70,7 @@ describe('PGPlugin', () => {
   before(async () => {
     tracer.start({ samplingRate: 1, logger: logger.logger(4) })
     tracer.registerSpanEventListener(rootSpanVerifier)
-    const basedir = path.dirname(require.resolve('pg'))
+    const basedir = path.dirname(require.resolve("pg/package.json")); //require.resolve was returning direct path to lib, as in current pg version they have defined "main" path section which was breaking this test case. We need only path of PG nodule not lib folder. This fixes this issue.
     plugin.enable(pg, tracer, VERSION, {}, basedir)
     client = new pg.Client(CONFIG)
     try {

--- a/src/census/plugins/pg.ts
+++ b/src/census/plugins/pg.ts
@@ -30,8 +30,8 @@ export class PGPlugin extends BasePlugin {
 
   protected options: PGPluginConfig
   protected readonly internalFileList = {
-    '7.x': {
-      'client': 'client'
+    '6 - 7': {  // Support version 6 as well as 7
+      'client': 'lib/client'  //Modified PG client path
     }
   }
 


### PR DESCRIPTION
Opencensus pg plugin path was incorrect, the modified path to lib/client.
Also, version support changed to 6 - 7 to support 6 as well as 7