### PR TITLE
Fix for Jest

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -14,8 +14,11 @@ export default class Configuration {
   }
 
   static findPackageJson () {
-
-    require.main = Configuration.getMain()
+    try {
+      require.main = Configuration.getMain()
+    } catch (_e) {
+      // Ignore error when getter is set on require.main, but no setter
+    }
 
     if (!require.main) {
       return


### PR DESCRIPTION
Problem: we are using `@pm2/io` programatically and we are using `jest` for tests.

`jest` sets (`node_modules/jest-runtime/build/index.js`) getter on `require.main`. This cause `@pm/io` to fail in `src/configuration.ts` with cryptic error:

```
    TypeError: Cannot set property main of function () { [native code] } which has only a getter
```