### PR TITLE
Update @opencensus packages to the latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "all": true
   },
   "dependencies": {
-    "@opencensus/core": "0.0.9",
-    "@opencensus/propagation-b3": "0.0.8",
+    "@opencensus/core": "0.1.0",
+    "@opencensus/propagation-b3": "0.1.0",
     "async": "~2.6.1",
     "debug": "~4.3.1",
     "eventemitter2": "^6.3.1",


### PR DESCRIPTION
Versions < 0.1.0 use an outdated version of [uuid](https://www.npmjs.com/package/uuid) and cause a deprecation warning to be raised:

![image](https://user-images.githubusercontent.com/2545170/182967125-ff99300f-83cf-4530-8658-2ec24d46b56f.png)

I ran an `npm ls uuid` to see where it came from:

![image](https://user-images.githubusercontent.com/2545170/182967418-85358743-3cda-4159-bf07-cee06d62d3e1.png)

I am more than happy to collaborate further if needed.