### PR TITLE
chore(deps): bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "all": true
   },
   "dependencies": {
-    "@opencensus/core": "0.0.9",
-    "@opencensus/propagation-b3": "0.0.8",
+    "@opencensus/core": "0.1.0",
+    "@opencensus/propagation-b3": "0.1.0",
     "async": "~2.6.1",
     "debug": "~4.3.1",
     "eventemitter2": "^6.3.1",


### PR DESCRIPTION
"Please upgrade  to version 7 or higher. Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details."
`@opencensus/core@0.1.0` and `@opencensus/propagation-b3@0.1.0` use `uuid@8.0.0`.
Please bump them to avoid this npm warn.