### PR TITLE
security: update semver dependency 6.3.0 → ~6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "debug": "~4.3.1",
     "eventemitter2": "^6.3.1",
     "require-in-the-middle": "^5.0.0",
-    "semver": "6.3.0",
+    "semver": "~6.3.0",
     "shimmer": "^1.2.0",
     "signal-exit": "^3.0.3",
     "tslib": "1.9.3"


### PR DESCRIPTION
This change allows `@pm2/io` to depend on `semver@6.3.1` which includes a fix for this vulnerability (https://www.cve.org/CVERecord?id=CVE-2022-25883)