### PR TITLE
Fix crash from undefined method when running under Deno 2

### DIFF
--- a/src/transports/IPCTransport.ts
+++ b/src/transports/IPCTransport.ts
@@ -40,7 +40,7 @@ export class IPCTransport extends EventEmitter2 implements Transport {
     this.autoExitHandle = setInterval(() => {
       let currentProcess: any = (cluster.isWorker) ? cluster.worker.process : process
 
-      if (currentProcess._getActiveHandles().length === 3) {
+      if (typeof currentProcess._getActiveHandles === 'function' && currentProcess._getActiveHandles().length === 3) {
         let handlers: any = currentProcess._getActiveHandles().map(h => h.constructor.name)
 
         if (handlers.includes('Pipe') === true &&


### PR DESCRIPTION
This addresses issue #305

It performs a safety check to ensure that the undocumented/private method `_getActiveHandles` exists on the process object before calling it.

I had thought about using the optional chaining operator, but figured it would be better for overall compatibility and style consistency to copy the same checking method as used [here](https://github.com/keymetrics/pm2-io-apm/blob/714ec396ca212e43e6129a6e2413b2be2c1b1aa1/src/metrics/eventLoopMetrics.ts#L63)